### PR TITLE
feat: search-front

### DIFF
--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { useAuth } from "../../context/AuthContext";
 import clsx from "clsx";
+import { CatalogSearch } from "../opensearch";
 
 export function Sidebar({ isCollapsed, onToggle }) {
   const navigate = useNavigate();
@@ -174,18 +175,7 @@ export function Topbar({ isCollapsed }) {
       )}
     >
       {/* Search */}
-      <div className="flex-1 max-w-xl">
-        <div className="relative">
-          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <Search className="h-4 w-4 text-gray-400" />
-          </div>
-          <input
-            type="text"
-            placeholder="Search assets, tables..."
-            className="block w-full pl-10 pr-3 py-2 border border-gray-200 rounded-lg leading-5 bg-gray-50 placeholder-gray-400 focus:outline-none focus:bg-white focus:ring-1 focus:ring-blue-500 focus:border-blue-500 sm:text-sm transition-colors"
-          />
-        </div>
-      </div>
+      <CatalogSearch />
 
       {/* Right Actions */}
       <div className="flex items-center space-x-4">

--- a/frontend/src/components/opensearch/CatalogSearch.jsx
+++ b/frontend/src/components/opensearch/CatalogSearch.jsx
@@ -1,0 +1,186 @@
+import { useState, useRef, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Search, RefreshCw, Database, Table, Loader2 } from 'lucide-react';
+import { useSearchCatalog, useTriggerIndexing } from '../../hooks/useOpenSearch';
+
+/**
+ * 카탈로그 검색 컴포넌트
+ * - 자동완성 검색 (디바운스 적용)
+ * - 인덱싱 새로고침 버튼
+ * - 검색 결과 드롭다운
+ */
+export default function CatalogSearch() {
+  const navigate = useNavigate();
+  const [query, setQuery] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const searchRef = useRef(null);
+
+  // 검색 API 호출 (디바운스 적용)
+  const { results, loading, error } = useSearchCatalog(query);
+
+  // 인덱싱 트리거
+  const { trigger: triggerIndexing, loading: indexing } = useTriggerIndexing();
+
+  // 검색 결과가 있으면 드롭다운 열기
+  useEffect(() => {
+    if (results.length > 0 && query.trim().length > 0) {
+      setIsOpen(true);
+    } else {
+      setIsOpen(false);
+    }
+  }, [results, query]);
+
+  // 외부 클릭 시 드롭다운 닫기
+  useEffect(() => {
+    function handleClickOutside(event) {
+      if (searchRef.current && !searchRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // 검색 결과 클릭 핸들러
+  const handleResultClick = (result) => {
+    // CatalogPage로 이동하면서 resource_name으로 검색
+    navigate(`/catalog?search=${encodeURIComponent(result.resource_name)}`);
+    setIsOpen(false);
+    setQuery('');
+  };
+
+  // 인덱싱 버튼 클릭
+  const handleRefresh = async () => {
+    try {
+      const result = await triggerIndexing();
+      console.log('Indexing completed:', result);
+      // TODO: 성공 토스트 메시지 표시
+    } catch (err) {
+      console.error('Indexing failed:', err);
+      // TODO: 에러 토스트 메시지 표시
+    }
+  };
+
+  // 결과를 database별로 그룹화
+  const groupedResults = results.reduce((acc, result) => {
+    const db = result.database;
+    if (!acc[db]) {
+      acc[db] = [];
+    }
+    acc[db].push(result);
+    return acc;
+  }, {});
+
+  return (
+    <div className="flex items-center gap-2 flex-1 max-w-xl" ref={searchRef}>
+      {/* 검색 Input */}
+      <div className="relative flex-1">
+        <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+          {loading ? (
+            <Loader2 className="h-4 w-4 text-gray-400 animate-spin" />
+          ) : (
+            <Search className="h-4 w-4 text-gray-400" />
+          )}
+        </div>
+        <input
+          type="text"
+          placeholder="Search tables, fields, databases..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => {
+            if (results.length > 0) setIsOpen(true);
+          }}
+          className="block w-full pl-10 pr-3 py-2 border border-gray-200 rounded-lg leading-5 bg-gray-50 placeholder-gray-400 focus:outline-none focus:bg-white focus:ring-1 focus:ring-blue-500 focus:border-blue-500 sm:text-sm transition-colors"
+        />
+
+        {/* 검색 결과 드롭다운 */}
+        {isOpen && (
+          <div className="absolute z-50 mt-2 w-full bg-white rounded-lg shadow-lg border border-gray-200 max-h-96 overflow-y-auto">
+            {error && (
+              <div className="p-4 text-sm text-red-600">
+                Error: {error}
+              </div>
+            )}
+
+            {!error && results.length === 0 && query.trim().length > 0 && !loading && (
+              <div className="p-4 text-sm text-gray-500 text-center">
+                No results found for "{query}"
+              </div>
+            )}
+
+            {!error && Object.keys(groupedResults).length > 0 && (
+              <div className="py-2">
+                {Object.entries(groupedResults).map(([database, items]) => (
+                  <div key={database} className="mb-2 last:mb-0">
+                    {/* Database Header */}
+                    <div className="px-4 py-2 bg-gray-50 border-b border-gray-100">
+                      <div className="flex items-center gap-2 text-xs font-semibold text-gray-700">
+                        <Database className="w-3.5 h-3.5" />
+                        {database}
+                        <span className="text-gray-400">({items.length})</span>
+                      </div>
+                    </div>
+
+                    {/* Results */}
+                    <div>
+                      {items.slice(0, 5).map((result, idx) => (
+                        <button
+                          key={`${result.database}-${result.resource_name}-${result.field_name}-${idx}`}
+                          onClick={() => handleResultClick(result)}
+                          className="w-full px-4 py-2.5 hover:bg-blue-50 transition-colors text-left border-b border-gray-50 last:border-b-0"
+                        >
+                          <div className="flex items-start gap-3">
+                            <div className="mt-0.5">
+                              <Table className="w-4 h-4 text-gray-400" />
+                            </div>
+                            <div className="flex-1 min-w-0">
+                              <div className="flex items-center gap-2 mb-1">
+                                <span className="font-medium text-sm text-gray-900 truncate">
+                                  {result.resource_name}
+                                </span>
+                                <span className="text-xs text-gray-400">•</span>
+                                <span className="text-xs text-gray-500 truncate">
+                                  {result.field_name}
+                                </span>
+                              </div>
+                              <div className="flex items-center gap-2 flex-wrap">
+                                <span className="text-xs px-1.5 py-0.5 bg-gray-100 text-gray-600 rounded">
+                                  {result.source}
+                                </span>
+                                <span className="text-xs text-gray-500">
+                                  {result.field_type}
+                                </span>
+                                {result.domain && (
+                                  <span className="text-xs px-1.5 py-0.5 bg-blue-50 text-blue-600 rounded">
+                                    {result.domain}
+                                  </span>
+                                )}
+                              </div>
+                            </div>
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* 새로고침 버튼 */}
+      <button
+        onClick={handleRefresh}
+        disabled={indexing}
+        title="Refresh catalog index"
+        className="p-2 rounded-lg hover:bg-gray-100 text-gray-500 hover:text-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        <RefreshCw
+          className={`w-5 h-5 ${indexing ? 'animate-spin' : ''}`}
+        />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/opensearch/index.js
+++ b/frontend/src/components/opensearch/index.js
@@ -1,0 +1,1 @@
+export { default as CatalogSearch } from './CatalogSearch';

--- a/frontend/src/hooks/useOpenSearch.js
+++ b/frontend/src/hooks/useOpenSearch.js
@@ -1,0 +1,109 @@
+import { useState, useEffect, useCallback } from 'react';
+import openSearchAPI from '../services/opensearch';
+
+/**
+ * 디바운스된 카탈로그 검색 hook
+ * @param {string} query - 검색어
+ * @param {number} delay - 디바운스 지연 시간 (ms)
+ * @returns {Object} 검색 결과 및 상태
+ */
+export function useSearchCatalog(query, delay = 300) {
+  const [results, setResults] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    // 검색어가 비어있으면 결과 초기화
+    if (!query || query.trim().length === 0) {
+      setResults([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    // 디바운스 타이머
+    const timer = setTimeout(async () => {
+      try {
+        const data = await openSearchAPI.searchCatalog(query);
+        setResults(data.results || []);
+      } catch (err) {
+        console.error('Search error:', err);
+        setError(err.message);
+        setResults([]);
+      } finally {
+        setLoading(false);
+      }
+    }, delay);
+
+    // 클린업: 타이머 취소
+    return () => clearTimeout(timer);
+  }, [query, delay]);
+
+  return { results, loading, error };
+}
+
+/**
+ * 인덱싱 트리거 hook
+ * @returns {Object} 인덱싱 함수 및 상태
+ */
+export function useTriggerIndexing() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [result, setResult] = useState(null);
+
+  const trigger = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await openSearchAPI.triggerIndexing();
+      setResult(data);
+      return data;
+    } catch (err) {
+      console.error('Indexing error:', err);
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { trigger, loading, error, result };
+}
+
+/**
+ * OpenSearch 상태 확인 hook
+ * @param {boolean} autoFetch - 자동 fetch 여부
+ * @returns {Object} 상태 정보
+ */
+export function useOpenSearchStatus(autoFetch = false) {
+  const [status, setStatus] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchStatus = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await openSearchAPI.getStatus();
+      setStatus(data);
+      return data;
+    } catch (err) {
+      console.error('Status check error:', err);
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (autoFetch) {
+      fetchStatus();
+    }
+  }, [autoFetch, fetchStatus]);
+
+  return { status, loading, error, fetchStatus };
+}

--- a/frontend/src/pages/catalog/CatalogPage.jsx
+++ b/frontend/src/pages/catalog/CatalogPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import {
     Search,
     Filter,
@@ -18,12 +18,21 @@ import { catalogAPI } from "../../services/catalog/index";
 
 export default function CatalogPage() {
     const navigate = useNavigate();
-    const [searchTerm, setSearchTerm] = useState("");
+    const [searchParams, setSearchParams] = useSearchParams();
+    const [searchTerm, setSearchTerm] = useState(searchParams.get('search') || "");
     // Catalog Data
     const [allTables, setAllTables] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [showCreateModal, setShowCreateModal] = useState(false);
+
+    // URL search 파라미터가 변경되면 searchTerm 업데이트
+    useEffect(() => {
+        const urlSearch = searchParams.get('search');
+        if (urlSearch) {
+            setSearchTerm(urlSearch);
+        }
+    }, [searchParams]);
 
     // TODO: Recently Used Tables 임의로 구현
     const recentTables = allTables.slice(0, 4);

--- a/frontend/src/services/opensearch.js
+++ b/frontend/src/services/opensearch.js
@@ -1,0 +1,71 @@
+/**
+ * OpenSearch API 서비스
+ * 데이터 카탈로그 검색 및 인덱싱 관리
+ */
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
+
+/**
+ * 카탈로그 검색
+ * @param {string} query - 검색어
+ * @param {string|null} source - 특정 소스 필터 ('s3' | 'mongodb')
+ * @param {number} limit - 결과 개수 제한 (1-100)
+ * @returns {Promise<Object>} 검색 결과
+ */
+export async function searchCatalog(query, source = null, limit = 20) {
+  const params = new URLSearchParams({ q: query, limit });
+  if (source) {
+    params.append('source', source);
+  }
+
+  const response = await fetch(
+    `${API_BASE_URL}/api/opensearch/search?${params.toString()}`
+  );
+
+  if (!response.ok) {
+    throw new Error(`Search failed: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * 수동 인덱싱 트리거
+ * @returns {Promise<Object>} 인덱싱 결과
+ */
+export async function triggerIndexing() {
+  const response = await fetch(`${API_BASE_URL}/api/opensearch/index`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Indexing failed: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * OpenSearch 상태 확인
+ * @returns {Promise<Object>} 상태 정보
+ */
+export async function getStatus() {
+  const response = await fetch(`${API_BASE_URL}/api/opensearch/status`);
+
+  if (!response.ok) {
+    throw new Error(`Status check failed: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+const openSearchAPI = {
+  searchCatalog,
+  triggerIndexing,
+  getStatus,
+};
+
+export default openSearchAPI;


### PR DESCRIPTION
Frontend:
  - Create OpenSearch service layer (services/opensearch.js)
  - Implement custom hooks with debounced search (hooks/useOpenSearch.js)
  - Add CatalogSearch component with auto-complete dropdown
  - Integrate search into Topbar with refresh button
  - Update CatalogPage to handle URL search parameters

  Features:
  - Auto-complete search (300ms debounce)
  - Database-grouped search results
  - Manual indexing trigger with loading state
  - Navigate to catalog page on result click
  - Display metadata: source, field type, domain, tags