### PR TITLE
fix(domain) fix lineage bug

### DIFF
--- a/frontend/src/pages/domain/components/schema-node/SchemaEtlView.jsx
+++ b/frontend/src/pages/domain/components/schema-node/SchemaEtlView.jsx
@@ -71,12 +71,12 @@ const EtlStepNode = ({ step, parentId, onExpandChange, onSelect, onScroll }) => 
     );
 };
 
-export const SchemaEtlView = ({ data, parentNodeId, onEtlStepSelect }) => {
+export const SchemaEtlView = ({ data, parentNodeId, onEtlStepSelect, refreshTrigger }) => {
     const jobs = data.jobs || [];
     const containerRef = useRef(null);
 
     // Logic extracted to hook
-    const { lines, refreshLines } = useEtlLineage(containerRef, jobs, parentNodeId, data.columns);
+    const { lines, refreshLines } = useEtlLineage(containerRef, jobs, parentNodeId, data.columns, refreshTrigger);
 
     return (
         <div ref={containerRef} className="p-5 rounded-xl shadow-2xl border border-gray-200/30 min-w-max relative"

--- a/frontend/src/pages/domain/components/schema-node/SchemaNode.jsx
+++ b/frontend/src/pages/domain/components/schema-node/SchemaNode.jsx
@@ -11,6 +11,7 @@ export const nodeHeight = 220;
 const SchemaNodeComponent = ({ id, data, selected }) => {
     const [schemaExpanded, setSchemaExpanded] = useState(true);
     const [etlOpen, setEtlOpen] = useState(false);
+    const [mainNodeScrollVersion, setMainNodeScrollVersion] = useState(0);
 
     // Data extraction
     const columns = data.columns || [];
@@ -103,7 +104,12 @@ const SchemaNodeComponent = ({ id, data, selected }) => {
             {/* Content Area: Columns (Always render if expanded) */}
             {schemaExpanded && (
                 <div id={`main-cols-${id}`}>
-                    <SchemaNodeColumns columns={columns} nodeId={id} withHandles={hasPermission} />
+                    <SchemaNodeColumns
+                        columns={columns}
+                        nodeId={id}
+                        withHandles={hasPermission}
+                        onScroll={() => setMainNodeScrollVersion(v => v + 1)}
+                    />
                 </div>
             )}
 
@@ -114,6 +120,7 @@ const SchemaNodeComponent = ({ id, data, selected }) => {
                         data={data}
                         parentNodeId={id}
                         onEtlStepSelect={data.onEtlStepSelect} // Pass handler
+                        refreshTrigger={mainNodeScrollVersion}
                     />
                 </div>
             )}

--- a/frontend/src/pages/domain/hooks/useEtlLineage.js
+++ b/frontend/src/pages/domain/hooks/useEtlLineage.js
@@ -23,7 +23,7 @@ export const groupNodesIntoLayers = (steps) => {
     return layers;
 };
 
-export const useEtlLineage = (containerRef, jobs, parentNodeId, dataColumns) => {
+export const useEtlLineage = (containerRef, jobs, parentNodeId, dataColumns, refreshTrigger) => {
     const [lines, setLines] = useState([]);
     const [redrawCount, setRedrawCount] = useState(0);
 
@@ -150,9 +150,7 @@ export const useEtlLineage = (containerRef, jobs, parentNodeId, dataColumns) => 
                                             || document.getElementById(tId1);
                                     }
 
-                                    if (sourceEl && targetEl && isVisible(sourceEl, sourceContainer)) {
-                                        // Note: We might want isVisible check for targetEl too if main node scrolls, 
-                                        // but for now focus on ETL step scrolling which is the main issue.
+                                    if (sourceEl && targetEl && isVisible(sourceEl, sourceContainer) && isVisible(targetEl, mainContainer)) {
                                         const sRect = sourceEl.getBoundingClientRect();
                                         const tRect = targetEl.getBoundingClientRect();
 
@@ -173,7 +171,7 @@ export const useEtlLineage = (containerRef, jobs, parentNodeId, dataColumns) => 
         }, 10);
 
         return () => clearTimeout(timer);
-    }, [jobs, redrawCount, dataColumns, parentNodeId, containerRef]);
+    }, [jobs, redrawCount, dataColumns, parentNodeId, containerRef, refreshTrigger]);
 
     return { lines, refreshLines };
 };


### PR DESCRIPTION
- 스크롤이 발생할 때마다 즉시 연결선들에게 위치를 업데이트
- 타겟 컬럼이 안 보이는데도 선이 엉뚱한 곳(허공)을 가리키거나, 노드 상/하단에 뭉쳐서 표시되는 이상한 현상을 방지했습니다.