### PR TITLE
feat: implement redis vector search for semantic caching

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -61,3 +61,4 @@ kubernetes
 pyarrow==18.1.0
 s3fs==2024.12.0
 redis>=5.0.0
+numpy>=1.24.0

--- a/backend/schemas/ai.py
+++ b/backend/schemas/ai.py
@@ -38,6 +38,17 @@ class GenerateSQLResponse(BaseModel):
     sql: str = Field(description="생성된 SQL 쿼리")
     schema_context: str = Field(description="사용된 스키마 정보")
 
+    # Semantic Cache 정보
+    cache_hit: bool = Field(default=False, description="캐시 히트 여부")
+    similarity: Optional[float] = Field(
+        default=None,
+        description="캐시된 질문과의 유사도 (0~1)"
+    )
+    cached_question: Optional[str] = Field(
+        default=None,
+        description="캐시에서 찾은 원본 질문"
+    )
+
 
 class SchemaSearchResult(BaseModel):
     """

--- a/backend/services/embedding_service.py
+++ b/backend/services/embedding_service.py
@@ -1,0 +1,81 @@
+"""
+임베딩 서비스 - AWS Bedrock Titan Embeddings 사용
+질문을 1024차원 벡터로 변환하여 의미 기반 검색 지원
+"""
+import os
+import json
+import boto3
+import numpy as np
+from typing import Optional
+
+
+class EmbeddingService:
+    """
+    AWS Bedrock Titan Embeddings를 사용한 텍스트 임베딩 서비스
+    """
+
+    def __init__(self):
+        self.region = os.getenv('AWS_REGION', 'ap-northeast-2')
+        # Titan Embeddings V2 모델 (1024 dimensions)
+        self.model_id = os.getenv(
+            'BEDROCK_EMBEDDING_MODEL_ID',
+            'amazon.titan-embed-text-v2:0'
+        )
+        self._client = None
+
+    @property
+    def client(self):
+        """Bedrock 클라이언트 (lazy initialization)"""
+        if self._client is None:
+            self._client = boto3.client(
+                'bedrock-runtime',
+                region_name=self.region,
+                endpoint_url=None  # Force real AWS Bedrock
+            )
+        return self._client
+
+    def get_embedding(self, text: str, normalize: bool = True) -> np.ndarray:
+        """
+        텍스트를 벡터(임베딩)로 변환
+
+        Args:
+            text: 임베딩할 텍스트 (질문)
+            normalize: L2 정규화 여부 (코사인 유사도에 최적화)
+
+        Returns:
+            1024차원 float32 numpy 배열
+        """
+        try:
+            # Titan Embeddings V2 요청
+            body = json.dumps({
+                "inputText": text,
+                "dimensions": 1024,
+                "normalize": normalize
+            })
+
+            response = self.client.invoke_model(
+                modelId=self.model_id,
+                body=body
+            )
+
+            result = json.loads(response['body'].read())
+            embedding = result['embedding']
+
+            # numpy array로 변환 (float32 - Redis Vector에 최적)
+            return np.array(embedding, dtype=np.float32)
+
+        except Exception as e:
+            print(f"Embedding error: {e}")
+            raise RuntimeError(f"Failed to generate embedding: {str(e)}")
+
+
+# 싱글톤 인스턴스
+_embedding_service = None
+
+
+def get_embedding_service() -> EmbeddingService:
+    """임베딩 서비스 싱글톤 반환"""
+    global _embedding_service
+    if _embedding_service is None:
+        _embedding_service = EmbeddingService()
+    return _embedding_service

--- a/backend/utils/redis_vector_client.py
+++ b/backend/utils/redis_vector_client.py
@@ -1,0 +1,193 @@
+"""
+Redis Vector Search 클라이언트
+의미 기반 캐싱을 위한 Vector Index 관리
+"""
+import os
+import redis
+from typing import Optional, Dict, Any
+import numpy as np
+
+
+class RedisVectorClient:
+    """
+    Redis Vector Search 전용 클라이언트
+
+    주의: Vector 데이터는 바이너리이므로 decode_responses=False 필요
+    """
+
+    def __init__(self):
+        self.client: Optional[redis.Redis] = None
+        self.index_name = "semantic_cache_idx"
+        self.key_prefix = "semantic:"
+        self.vector_dim = 1024  # Titan Embeddings V2 dimension
+
+    def connect(self) -> redis.Redis:
+        """Redis 연결 (동기, Vector Search용)"""
+        if self.client is None:
+            self.client = redis.Redis(
+                host=os.getenv("REDIS_HOST", "redis-master"),
+                port=int(os.getenv("REDIS_PORT", 6379)),
+                password=os.getenv("REDIS_PASSWORD", "redis123"),
+                decode_responses=False,  # Vector 데이터는 바이너리
+            )
+        return self.client
+
+    def create_index(self):
+        """
+        Vector Search 인덱스 생성
+
+        Schema:
+        - question (TEXT): 원본 질문 (검색 가능)
+        - embedding (VECTOR): 1024차원 벡터 (HNSW 알고리즘)
+        - sql_query (TEXT): 저장된 SQL
+        - timestamp (NUMERIC): 생성 시간
+        """
+        try:
+            client = self.connect()
+            # 기존 인덱스 존재 여부 확인
+            client.ft(self.index_name).info()
+            print(f"✓ Vector index '{self.index_name}' already exists")
+        except redis.exceptions.ResponseError:
+            # 인덱스 없음 - 새로 생성
+            from redis.commands.search.field import TextField, VectorField, NumericField
+            from redis.commands.search.indexDefinition import IndexDefinition, IndexType
+
+            schema = (
+                TextField("question"),
+                VectorField(
+                    "embedding",
+                    "HNSW",  # Hierarchical Navigable Small World (고속 근사 검색)
+                    {
+                        "TYPE": "FLOAT32",
+                        "DIM": self.vector_dim,
+                        "DISTANCE_METRIC": "COSINE",  # 코사인 유사도
+                        "INITIAL_CAP": 10000,  # 초기 용량
+                    }
+                ),
+                TextField("sql_query"),
+                NumericField("timestamp"),
+            )
+
+            definition = IndexDefinition(
+                prefix=[self.key_prefix],
+                index_type=IndexType.HASH
+            )
+
+            client.ft(self.index_name).create_index(
+                fields=schema,
+                definition=definition
+            )
+            print(f"✓ Vector index '{self.index_name}' created successfully")
+
+    def search_similar(
+        self,
+        query_vector: np.ndarray,
+        top_k: int = 1,
+        threshold: float = 0.95
+    ) -> Optional[Dict[str, Any]]:
+        """
+        벡터 유사도 검색 (KNN)
+
+        Args:
+            query_vector: 질문 벡터 (1024 dim)
+            top_k: 상위 K개 결과
+            threshold: 최소 유사도 (0.95 = 95%)
+
+        Returns:
+            {question, sql_query, similarity} 또는 None
+        """
+        try:
+            client = self.connect()
+            from redis.commands.search.query import Query
+
+            # KNN 쿼리 (COSINE distance)
+            q = (
+                Query(f"(*)=>[KNN {top_k} @embedding $vector AS score]")
+                .return_fields("question", "sql_query", "score")
+                .dialect(2)
+            )
+
+            params = {"vector": query_vector.tobytes()}
+            results = client.ft(self.index_name).search(q, params)
+
+            if results.total > 0:
+                doc = results.docs[0]
+                # Cosine distance → similarity (1 - distance)
+                similarity = 1 - float(doc.score)
+
+                if similarity >= threshold:
+                    return {
+                        "question": doc.question.decode('utf-8'),
+                        "sql_query": doc.sql_query.decode('utf-8'),
+                        "similarity": similarity
+                    }
+
+            return None
+
+        except Exception as e:
+            print(f"Vector search error: {e}")
+            return None
+
+    def save_cache(
+        self,
+        question: str,
+        embedding: np.ndarray,
+        sql_query: str
+    ):
+        """
+        벡터 캐시 저장 (LRU가 자동으로 메모리 관리)
+
+        Args:
+            question: 원본 질문
+            embedding: 질문 벡터
+            sql_query: 생성된 SQL
+        """
+        import hashlib
+        import time
+
+        client = self.connect()
+
+        # 질문 해시를 키로 사용
+        key_hash = hashlib.md5(question.encode()).hexdigest()
+        key = f"{self.key_prefix}{key_hash}"
+
+        # HASH로 저장
+        mapping = {
+            "question": question.encode('utf-8'),
+            "embedding": embedding.tobytes(),
+            "sql_query": sql_query.encode('utf-8'),
+            "timestamp": str(int(time.time())).encode('utf-8')
+        }
+
+        client.hset(key, mapping=mapping)
+        # TTL 설정 없음 - LRU가 알아서 관리
+
+        print(f"✓ Cached: {question[:50]}... (key: {key_hash[:8]})")
+
+    def get_memory_info(self) -> Dict[str, Any]:
+        """Redis 메모리 사용량 조회"""
+        client = self.connect()
+        info = client.info('memory')
+        return {
+            "used_memory": info.get('used_memory_human'),
+            "used_memory_rss": info.get('used_memory_rss_human'),
+            "maxmemory": info.get('maxmemory_human'),
+            "total_keys": client.dbsize()
+        }
+
+
+# 싱글톤 인스턴스
+_redis_vector_client = None
+
+
+def get_redis_vector_client() -> RedisVectorClient:
+    """Redis Vector 클라이언트 싱글톤 반환"""
+    global _redis_vector_client
+    if _redis_vector_client is None:
+        _redis_vector_client = RedisVectorClient()
+        # 애플리케이션 시작 시 인덱스 자동 생성
+        try:
+            _redis_vector_client.create_index()
+        except Exception as e:
+            print(f"⚠️  Vector index creation failed (will retry on first use): {e}")
+    return _redis_vector_client

--- a/k8s/backend/configmap.yaml
+++ b/k8s/backend/configmap.yaml
@@ -26,3 +26,9 @@ data:
   REDIS_HOST: "redis-stack"
   REDIS_PORT: "6379"
   REDIS_PASSWORD: ""
+  # Semantic Cache configuration
+  SEMANTIC_CACHE_ENABLED: "true"
+  SEMANTIC_CACHE_THRESHOLD: "0.95"
+  # Bedrock configuration
+  BEDROCK_MODEL_ID: "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+  BEDROCK_EMBEDDING_MODEL_ID: "amazon.titan-embed-text-v2:0"


### PR DESCRIPTION
- Add embedding service with AWS Bedrock Titan Embeddings
- Add Redis Vector client with HNSW index(비교하는 검색 알고리즘)
- Integrate semantic cache in BedrockService
- Update AI response schema with cache info
- Add numpy to requirements.txt : 벡터 계산
- Update K8s ConfigMap for semantic cache settings : 유사도 셋팅