### PR TITLE
feat: catlog linege layout save

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -156,6 +156,10 @@ class Dataset(Document):
     nodes: Optional[List[dict]] = None
     edges: Optional[List[dict]] = None
 
+    # Lineage layout (stores node positions for catalog detail page)
+    # Example: {"nodes": [{"id": "node1", "position": {"x": 100, "y": 200}}]}
+    lineage_layout: Optional[dict] = None
+
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 

--- a/backend/routers/catalog.py
+++ b/backend/routers/catalog.py
@@ -277,6 +277,52 @@ async def delete_lineage(
     return result
 
 
+@router.put("/{id}/layout")
+async def save_lineage_layout(id: str, layout: Dict[str, Any] = Body(...)):
+    """
+    Save lineage layout (node positions) for a dataset.
+    Layout should be in format: {"nodes": [{"id": "node1", "position": {"x": 100, "y": 200}}]}
+    """
+    db = database.mongodb_client[database.DATABASE_NAME]
+
+    try:
+        obj_id = ObjectId(id)
+    except:
+        raise HTTPException(status_code=400, detail="Invalid ID format")
+
+    # Update lineage_layout field
+    result = await db.datasets.update_one(
+        {"_id": obj_id},
+        {"$set": {"lineage_layout": layout}}
+    )
+
+    if result.matched_count == 0:
+        raise HTTPException(status_code=404, detail="Dataset not found")
+
+    return {"success": True, "message": "Layout saved successfully"}
+
+
+@router.get("/{id}/layout")
+async def get_lineage_layout(id: str):
+    """
+    Get saved lineage layout for a dataset.
+    Returns null if no layout is saved.
+    """
+    db = database.mongodb_client[database.DATABASE_NAME]
+
+    try:
+        obj_id = ObjectId(id)
+    except:
+        raise HTTPException(status_code=400, detail="Invalid ID format")
+
+    doc = await db.datasets.find_one({"_id": obj_id}, {"lineage_layout": 1})
+
+    if not doc:
+        raise HTTPException(status_code=404, detail="Dataset not found")
+
+    return {"layout": doc.get("lineage_layout")}
+
+
 
 
 

--- a/frontend/src/services/catalog/index.js
+++ b/frontend/src/services/catalog/index.js
@@ -65,13 +65,44 @@ export const catalogAPI = {
 
     /**
      * Fetch lineage data for a dataset
-     * @param {string} id 
+     * @param {string} id
      * @returns {Promise<Object>}
      */
     getLineage: async (id) => {
         const response = await fetch(`${API_URL}/${id}/lineage`);
         if (!response.ok) {
             throw new Error(`Failed to load lineage: ${response.statusText}`);
+        }
+        return await response.json();
+    },
+
+    /**
+     * Save lineage layout (node positions) for a dataset
+     * @param {string} id - Dataset ID
+     * @param {Object} layout - Layout data with node positions
+     * @returns {Promise<Object>}
+     */
+    saveLayout: async (id, layout) => {
+        const response = await fetch(`${API_URL}/${id}/layout`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(layout)
+        });
+        if (!response.ok) {
+            throw new Error(`Failed to save layout: ${response.statusText}`);
+        }
+        return await response.json();
+    },
+
+    /**
+     * Get saved lineage layout for a dataset
+     * @param {string} id - Dataset ID
+     * @returns {Promise<Object>}
+     */
+    getLayout: async (id) => {
+        const response = await fetch(`${API_URL}/${id}/layout`);
+        if (!response.ok) {
+            throw new Error(`Failed to load layout: ${response.statusText}`);
         }
         return await response.json();
     },


### PR DESCRIPTION
백엔드
- [[models.py]): Dataset 모델에 lineage_layout 필드 추가
- [[catalog.py]): 레이아웃 저장/조회 API 엔드포인트 추가
    - PUT /api/catalog/{id}/layout - 레이아웃 저장
    - GET /api/catalog/{id}/layout - 레이아웃 조회
프론트엔드 API 서비스
- services/catalog/index.js: saveLayout(), getLayout() 함수 추가
 UI 기능
- 자동 저장: 노드를 드래그하면 1초 후 자동으로 백엔드에 저장 (디바운스)
- 자동 로드: 페이지 로드 시 저장된 레이아웃 자동 복원
- 저장 상태 표시: 우측 상단에 저장 상태 표시
- React Flow의 기본 smooth zoom 사용